### PR TITLE
회원가입 과정 보완 (#3)

### DIFF
--- a/src/components/socialSignIn.tsx
+++ b/src/components/socialSignIn.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FirebaseError } from 'firebase/app';
 import { AuthProvider, signInWithPopup } from 'firebase/auth';
-import { auth } from '../firebase.ts';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '../firebase.ts';
 import * as S from '../styles/auth.ts';
 
 interface ISocialButton {
@@ -22,7 +23,13 @@ export default function SocialSignIn({ provider, icon, text }: ISocialButton) {
   const onClick = async () => {
     setFirebaseError('');
     try {
-      await signInWithPopup(auth, provider);
+      const credentials = await signInWithPopup(auth, provider);
+      const userRef = doc(db, 'users', credentials.user.uid);
+      await setDoc(userRef, {
+        userName: credentials.user.displayName || 'Anonymous',
+        userId: credentials.user.uid,
+        userAvatar: credentials.user.photoURL || null,
+      });
       navigate('/');
     } catch (error) {
       if (error instanceof FirebaseError) {


### PR DESCRIPTION
[🥁 : feat] 소셜로그인 시, 유저 정보 firestore에 저장 (#3)
- 프로필 이미지를 다루는 과정에서 회원의 정보를 firestore에 저장할 필요성을 확인. 이메일/비밀번호 회원가입 시 적용은 이전 작업에서 완료 (75ed77b)