### PR TITLE
프로필 수정하기 기능 업그레이드 (#5 #9) & 공통 개편사항 적용 (#17 #18)

### DIFF
--- a/src/components/edit-profile-form.tsx
+++ b/src/components/edit-profile-form.tsx
@@ -10,6 +10,7 @@ import {
 import { auth, db, storage } from '../firebase.ts';
 import IUser from '../interfaces/IUser.ts';
 import CompressImage from '../utils/compress-image.tsx';
+import useEscClose from '../utils/use-esc-close.tsx';
 import * as S from '../styles/profile-form.ts';
 import { ReactComponent as IconUser } from '../assets/images/i-user.svg';
 import { ReactComponent as LoadingSpinner } from '../assets/images/loading-spinner-mini.svg';
@@ -92,6 +93,7 @@ export default function EditProfileForm({
       onClose();
     }
   };
+  useEscClose(onClose);
   return (
     <S.Form onSubmit={onSubmit}>
       {avatarPreview ? (

--- a/src/components/edit-profile-form.tsx
+++ b/src/components/edit-profile-form.tsx
@@ -1,3 +1,131 @@
-export default function EditProfileForm() {
-  return <form></form>;
+import React, { useState } from 'react';
+import { updateProfile } from 'firebase/auth';
+import { doc, updateDoc } from 'firebase/firestore';
+import {
+  deleteObject,
+  getDownloadURL,
+  ref,
+  uploadBytes,
+} from 'firebase/storage';
+import { auth, db, storage } from '../firebase.ts';
+import IUser from '../interfaces/IUser.ts';
+import CompressImage from '../utils/compress-image.tsx';
+import * as S from '../styles/profile-form.ts';
+import { ReactComponent as IconUser } from '../assets/images/i-user.svg';
+import { ReactComponent as LoadingSpinner } from '../assets/images/loading-spinner-mini.svg';
+
+interface IEditProfileForm extends Pick<IUser, 'userAvatar' | 'userName'> {
+  onClose: () => void;
+}
+
+export default function EditProfileForm({
+  userAvatar: initialAvatar,
+  userName: initialName,
+  onClose,
+}: IEditProfileForm) {
+  const user = auth.currentUser;
+  const [isLoading, setLoading] = useState(false);
+  const [avatar, setAvatar] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState(user?.photoURL);
+  const onAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const images = e.target.files;
+    if (images && images.length === 1) {
+      const selectedImage = images[0];
+      const compressedImage = await CompressImage({
+        imageFile: selectedImage,
+        size: 200,
+      });
+      setAvatar(compressedImage);
+      const previewUrl = compressedImage
+        ? URL.createObjectURL(compressedImage)
+        : '';
+      setAvatarPreview(previewUrl);
+    }
+  };
+  const onAvatarDelete = () => {
+    setAvatar(null);
+    setAvatarPreview(null);
+  };
+
+  const [name, setName] = useState(initialName);
+  const onNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user || isLoading || name === '') return;
+    try {
+      setLoading(true);
+      const userDocRef = doc(db, 'users', user.uid);
+      await updateDoc(userDocRef, {
+        userName: name,
+      });
+      await updateProfile(user, {
+        displayName: name,
+      });
+      const locationRef = ref(storage, `avatars/${user?.uid}`);
+      if (avatar) {
+        const result = await uploadBytes(locationRef, avatar);
+        const url = await getDownloadURL(result.ref);
+        await updateDoc(userDocRef, {
+          userAvatar: url,
+        });
+        await updateProfile(user, {
+          photoURL: url,
+        });
+      } else if (!avatar && initialAvatar && initialAvatar !== avatarPreview) {
+        await updateProfile(user, {
+          photoURL: '',
+        });
+        await deleteObject(locationRef);
+        await updateDoc(userDocRef, {
+          userAvatar: null,
+        });
+      }
+      setAvatarPreview(null);
+      setAvatar(null);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setLoading(false);
+      onClose();
+    }
+  };
+  return (
+    <S.Form onSubmit={onSubmit}>
+      {avatarPreview ? (
+        <>
+          <S.AttachAvatarPreview
+            src={avatarPreview}
+            alt="프로필이미지 미리보기"
+            width="120"
+            height="120"
+          />
+          <S.AttachAvatarDelete type="button" onClick={onAvatarDelete} />
+        </>
+      ) : (
+        <S.AttachAvatarButton htmlFor="avatar_edit">
+          <IconUser />
+        </S.AttachAvatarButton>
+      )}
+      <S.AttachAvatarInput
+        onChange={onAvatarChange}
+        id="avatar_edit"
+        type="file"
+        accept="image/*"
+      />
+      <S.InputText
+        onChange={onNameChange}
+        name="name_edit"
+        type="text"
+        placeholder="이름을 입력해주세요"
+        value={name}
+        required
+      />
+      <S.SubmitButton type="submit">
+        {isLoading ? <LoadingSpinner /> : '수정'}
+      </S.SubmitButton>
+    </S.Form>
+  );
 }

--- a/src/components/edit-profile-form.tsx
+++ b/src/components/edit-profile-form.tsx
@@ -1,0 +1,3 @@
+export default function EditProfileForm() {
+  return <form></form>;
+}

--- a/src/components/edit-tweet-form.tsx
+++ b/src/components/edit-tweet-form.tsx
@@ -9,6 +9,7 @@ import {
 import { auth, db, storage } from '../firebase.ts';
 import ITweet from '../interfaces/ITweet.ts';
 import CompressImage from '../utils/compress-image.tsx';
+import useEscClose from '../utils/use-esc-close.tsx';
 import * as S from '../styles/tweet-form.ts';
 import { ReactComponent as IconPhoto } from '../assets/images/i-photo.svg';
 import { ReactComponent as LoadingSpinner } from '../assets/images/loading-spinner-mini.svg';
@@ -24,7 +25,6 @@ export default function EditTweetForm({
   onClose,
 }: IEditTweetForm) {
   const [isLoading, setLoading] = useState(false);
-
   const [tweet, setTweet] = useState(initialTweet);
   const onTweetChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTweet(e.target.value);
@@ -87,6 +87,7 @@ export default function EditTweetForm({
       onClose();
     }
   };
+  useEscClose(onClose);
   return (
     <S.EditForm onSubmit={onSubmit}>
       <S.TextArea

--- a/src/components/edit-tweet-form.tsx
+++ b/src/components/edit-tweet-form.tsx
@@ -24,13 +24,14 @@ export default function EditTweetForm({
   onClose,
 }: IEditTweetForm) {
   const [isLoading, setLoading] = useState(false);
-  const [tweet, setTweet] = useState(initialTweet);
-  const [image, setImage] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState(initialPhoto);
 
-  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const [tweet, setTweet] = useState(initialTweet);
+  const onTweetChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTweet(e.target.value);
   };
+
+  const [image, setImage] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState(initialPhoto);
   const onImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const images = e.target.files;
     if (images && images.length === 1) {
@@ -50,6 +51,7 @@ export default function EditTweetForm({
     setImage(null);
     setImagePreview('');
   };
+
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const user = auth.currentUser;
@@ -88,15 +90,21 @@ export default function EditTweetForm({
   return (
     <S.EditForm onSubmit={onSubmit}>
       <S.TextArea
-        onChange={onChange}
+        onChange={onTweetChange}
         value={tweet}
         rows={5}
         maxLength={180}
         placeholder="지금 무슨 일이 일어나고 있나요?"
+        required
       />
       {imagePreview ? (
         <>
-          <S.AttachImagePreview src={imagePreview} alt="첨부이미지 미리보기" />
+          <S.AttachImagePreview
+            src={imagePreview}
+            alt="첨부이미지 미리보기"
+            width="120"
+            height="120"
+          />
           <S.AttachImageDelete type="button" onClick={onImageDelete} />
         </>
       ) : (
@@ -106,8 +114,8 @@ export default function EditTweetForm({
       )}
       <S.AttachImageInput
         onChange={onImageChange}
-        type="file"
         id="image_edit"
+        type="file"
         accept="image/*"
       />
       <S.SubmitButton type="submit">

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FirebaseError } from 'firebase/app';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '../firebase.ts';
+import useEscClose from '../utils/use-esc-close.tsx';
 import * as S from '../styles/auth.ts';
 import * as P from '../styles/popup.ts';
 import ImageComputer from '../assets/images/logo-small.png';
@@ -25,17 +26,6 @@ export default function SignIn({ onClose }: ISignInProps) {
   const [userEmail, setUserEmail] = useState('');
   const [userPassword, setUserPassword] = useState('');
   const [firebaseError, setFirebaseError] = useState('');
-  useEffect(() => {
-    const handleEscKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscKey);
-    return () => {
-      document.removeEventListener('keydown', handleEscKey);
-    };
-  }, [onClose]);
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const {
       target: { name, value },
@@ -62,6 +52,7 @@ export default function SignIn({ onClose }: ISignInProps) {
       setLoading(false);
     }
   };
+  useEscClose(onClose);
   return (
     <P.PopupWrapper>
       <P.Popup>

--- a/src/components/sign-up.tsx
+++ b/src/components/sign-up.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FirebaseError } from 'firebase/app';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
 import { auth, db } from '../firebase.ts';
+import useEscClose from '../utils/use-esc-close.tsx';
 import * as S from '../styles/auth.ts';
 import * as P from '../styles/popup.ts';
 import ImageComputer from '../assets/images/logo-small.png';
@@ -27,17 +28,6 @@ export default function SignUp({ onClose }: ISignUpProps) {
   const [userEmail, setUserEmail] = useState('');
   const [userPassword, setUserPassword] = useState('');
   const [firebaseError, setFirebaseError] = useState('');
-  useEffect(() => {
-    const handleEscKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscKey);
-    return () => {
-      document.removeEventListener('keydown', handleEscKey);
-    };
-  }, [onClose]);
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const {
       target: { name, value },
@@ -80,6 +70,7 @@ export default function SignUp({ onClose }: ISignUpProps) {
       setLoading(false);
     }
   };
+  useEscClose(onClose);
   return (
     <P.PopupWrapper>
       <P.Popup>

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -44,11 +44,13 @@ export default function Timeline() {
       }
     };
   }, []);
-  return (
+  return tweets.length !== 0 ? (
     <S.TimelineWrapper>
       {tweets.map((tweet) => (
         <Tweet key={tweet.id} {...tweet} />
       ))}
     </S.TimelineWrapper>
+  ) : (
+    <S.Text>작성된 글이 없습니다.</S.Text>
   );
 }

--- a/src/components/tweet.tsx
+++ b/src/components/tweet.tsx
@@ -91,7 +91,7 @@ export default function Tweet({
               id={id}
               tweet={tweet}
               photo={photo}
-              onClose={() => setEditPopup(false)}
+              onClose={toggleEditPopup}
             />
           </P.Popup>
         </P.PopupWrapper>

--- a/src/components/user-profile.tsx
+++ b/src/components/user-profile.tsx
@@ -48,7 +48,11 @@ export default function UserProfile() {
         <P.PopupWrapper>
           <P.Popup>
             <P.CloseButton onClick={toggleEditPopup} type="button" />
-            <EditProfileForm />
+            <EditProfileForm
+              userAvatar={userAvatar}
+              userName={userName}
+              onClose={toggleEditPopup}
+            />
           </P.Popup>
         </P.PopupWrapper>
       ) : null}

--- a/src/components/user-profile.tsx
+++ b/src/components/user-profile.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { auth, db } from '../firebase.ts';
+import * as S from '../styles/profile.ts';
+import * as P from '../styles/popup.ts';
+import { ReactComponent as IconUser } from '../assets/images/i-user.svg';
+import EditProfileForm from './edit-profile-form.tsx';
+
+export default function UserProfile() {
+  const user = auth.currentUser;
+  const [userAvatar, setUserAvatar] = useState('');
+  const [userName, setUserName] = useState('');
+  useEffect(() => {
+    const fetchUserData = async () => {
+      if (!user) return;
+      const userDoc = await getDoc(doc(db, 'users', user?.uid));
+      if (userDoc.exists()) {
+        const userData = userDoc.data();
+        setUserAvatar(userData.userAvatar);
+        setUserName(userData.userName);
+      }
+    };
+    fetchUserData();
+  }, []);
+  const [editPopup, setEditPopup] = useState(false);
+  const toggleEditPopup = () => {
+    setEditPopup(!editPopup);
+  };
+  return (
+    <S.Profile>
+      <S.Avatar>
+        {userAvatar ? (
+          <S.AvatarImage
+            src={userAvatar}
+            alt="프로필 이미지"
+            width="120"
+            height="120"
+          />
+        ) : (
+          <IconUser />
+        )}
+      </S.Avatar>
+      <S.Name>{userName}</S.Name>
+      <S.EditButton onClick={toggleEditPopup} type="button">
+        프로필 수정
+      </S.EditButton>
+      {editPopup ? (
+        <P.PopupWrapper>
+          <P.Popup>
+            <P.CloseButton onClick={toggleEditPopup} type="button" />
+            <EditProfileForm />
+          </P.Popup>
+        </P.PopupWrapper>
+      ) : null}
+    </S.Profile>
+  );
+}

--- a/src/components/user-timeline.tsx
+++ b/src/components/user-timeline.tsx
@@ -9,9 +9,9 @@ import {
   where,
 } from 'firebase/firestore';
 import { auth, db } from '../firebase.ts';
+import ITweet from '../interfaces/ITweet.ts';
 import Tweet from './tweet.tsx';
 import * as S from '../styles/timeline.ts';
-import ITweet from '../interfaces/ITweet.ts';
 
 export default function UserTimeline() {
   const user = auth.currentUser;
@@ -47,11 +47,13 @@ export default function UserTimeline() {
       }
     };
   }, []);
-  return (
+  return tweets.length !== 0 ? (
     <S.TimelineWrapper>
       {tweets.map((tweet) => (
         <Tweet key={tweet.id} {...tweet} />
       ))}
     </S.TimelineWrapper>
+  ) : (
+    <S.Text>작성된 글이 없습니다.</S.Text>
   );
 }

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -1,0 +1,5 @@
+export default interface IUser {
+  userId: string;
+  userName: string;
+  userAvatar: string;
+}

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,69 +1,13 @@
-import React, { useState } from 'react';
-import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
-import { updateProfile } from 'firebase/auth';
-import { doc, updateDoc } from 'firebase/firestore';
-import { auth, db, storage } from '../firebase.ts';
-import CompressImage from '../utils/compress-image.tsx';
 import WindowTop from '../components/window-top.tsx';
 import UserTimeline from '../components/user-timeline.tsx';
 import * as W from '../styles/window.ts';
-import * as S from '../styles/profile.ts';
-import { ReactComponent as IconUser } from '../assets/images/i-user.svg';
+import UserProfile from '../components/user-profile.tsx';
 
 export default function Profile() {
-  const user = auth.currentUser;
-  const [avatar, setAvatar] = useState(user?.photoURL);
-  const updateUserAvatar = async (uid: string, newAvatarUrl: string) => {
-    const userDocRef = doc(db, 'users', uid);
-    await updateDoc(userDocRef, {
-      userAvatar: newAvatarUrl,
-    });
-  };
-  const onAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const images = e.target.files;
-    if (!user) return;
-    if (images && images.length === 1) {
-      const selectedImage = images[0];
-      const compressedImage = await CompressImage({
-        imageFile: selectedImage,
-        size: 120,
-      });
-      const locationRef = ref(storage, `avatars/${user?.uid}`);
-      if (compressedImage) {
-        const result = await uploadBytes(locationRef, compressedImage);
-        const avatarUrl = await getDownloadURL(result.ref);
-        setAvatar(avatarUrl);
-        await updateProfile(user, {
-          photoURL: avatarUrl,
-        });
-        await updateUserAvatar(user.uid, avatarUrl);
-      }
-    }
-  };
   return (
     <W.Window>
       <WindowTop />
-      <S.Avatar>
-        <S.AvatarUpload htmlFor="avatar">
-          {avatar ? (
-            <S.AvatarImage
-              src={avatar}
-              alt="프로필 이미지"
-              width="120"
-              height="120"
-            />
-          ) : (
-            <IconUser />
-          )}
-        </S.AvatarUpload>
-        <S.AvatarInput
-          onChange={onAvatarChange}
-          id="avatar"
-          type="file"
-          accept="image/*"
-        />
-        <S.Name>{user?.displayName ?? 'Anonymous'}</S.Name>
-      </S.Avatar>
+      <UserProfile />
       <UserTimeline />
     </W.Window>
   );

--- a/src/styles/profile-form.ts
+++ b/src/styles/profile-form.ts
@@ -1,0 +1,78 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import { primaryColor, whiteColor } from './global.ts';
+import { Input, SolidButton } from './button.ts';
+import { Avatar } from './profile.ts';
+
+export const Form = styled.form`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const AttachAvatarPreview = styled.img`
+  width: 120px;
+  height: 120px;
+  margin-bottom: 20px;
+  object-fit: cover;
+  border-radius: 50%;
+`;
+
+export const AttachAvatarDelete = styled.button`
+  position: absolute;
+  top: 0;
+  right: 70px;
+  width: 25px;
+  height: 25px;
+  background-color: ${primaryColor};
+  border: 2px solid ${whiteColor};
+  border-radius: 50%;
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: 10px;
+    left: 4px;
+    width: 13px;
+    height: 2px;
+    background-color: ${whiteColor};
+  }
+  &::before {
+    transform: rotate(45deg);
+  }
+  &::after {
+    transform: rotate(135deg);
+  }
+`;
+
+export const AttachAvatarButton: React.ComponentType<
+  React.HTMLProps<HTMLLabelElement>
+> = styled(Avatar).attrs(() => ({
+  as: 'label',
+}))`
+  margin-bottom: 20px;
+  cursor: pointer;
+  svg,
+  &::before {
+    transition: all 0.5s ease;
+  }
+  &:hover,
+  &:active {
+    svg {
+      stroke: ${primaryColor};
+    }
+    &::before {
+      border: 2px dashed ${primaryColor};
+    }
+  }
+`;
+
+export const AttachAvatarInput = styled.input`
+  display: none;
+`;
+
+export const InputText = styled(Input)``;
+
+export const SubmitButton = styled(SolidButton)``;

--- a/src/styles/profile.ts
+++ b/src/styles/profile.ts
@@ -1,5 +1,4 @@
 import { styled } from 'styled-components';
-import React from 'react';
 import { grayColor } from './global.ts';
 import { LineButton } from './button.ts';
 
@@ -10,7 +9,7 @@ export const Profile = styled.article`
   justify-content: center;
   align-items: center;
   gap: 20px;
-  padding: 50px 0;
+  padding: 50px 0 60px;
   &::after {
     content: '';
     position: absolute;
@@ -50,23 +49,11 @@ export const Avatar = styled.div`
   }
 `;
 
-export const AvatarUpload: React.ComponentType<
-  React.HTMLProps<HTMLLabelElement>
-> = styled(Avatar).attrs(() => ({
-  as: 'label',
-}))`
-  cursor: pointer;
-`;
-
 export const AvatarImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
   z-index: 10;
-`;
-
-export const AvatarInput = styled.input`
-  display: none;
 `;
 
 export const Name = styled.h2`

--- a/src/styles/profile.ts
+++ b/src/styles/profile.ts
@@ -1,7 +1,9 @@
 import { styled } from 'styled-components';
+import React from 'react';
 import { grayColor } from './global.ts';
+import { LineButton } from './button.ts';
 
-export const Avatar = styled.div`
+export const Profile = styled.article`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -21,7 +23,7 @@ export const Avatar = styled.div`
   }
 `;
 
-export const AvatarUpload = styled.label`
+export const Avatar = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
@@ -30,7 +32,6 @@ export const AvatarUpload = styled.label`
   width: 120px;
   height: 120px;
   border-radius: 50%;
-  cursor: pointer;
   svg {
     width: 40px;
     stroke: ${grayColor};
@@ -49,6 +50,14 @@ export const AvatarUpload = styled.label`
   }
 `;
 
+export const AvatarUpload: React.ComponentType<
+  React.HTMLProps<HTMLLabelElement>
+> = styled(Avatar).attrs(() => ({
+  as: 'label',
+}))`
+  cursor: pointer;
+`;
+
 export const AvatarImage = styled.img`
   width: 100%;
   height: 100%;
@@ -62,4 +71,9 @@ export const AvatarInput = styled.input`
 
 export const Name = styled.h2`
   font-size: 30px;
+`;
+
+export const EditButton = styled(LineButton)`
+  width: auto;
+  margin: 0;
 `;

--- a/src/styles/tweet-form.ts
+++ b/src/styles/tweet-form.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { blackColor, grayColor, primaryColor, whiteColor } from './global.ts';
+import { SolidButton } from './button.ts';
 
 export const Form = styled.form`
   position: relative;
@@ -8,10 +9,10 @@ export const Form = styled.form`
   flex-shrink: 0;
   gap: 10px;
   width: 100%;
-  padding-bottom: 20px;
 `;
 
 export const PostForm = styled(Form)`
+  padding-bottom: 10px;
   &::after {
     content: '';
     position: absolute;
@@ -97,7 +98,7 @@ export const AttachImageButton = styled.label`
     width: 30px;
     height: 30px;
     stroke: ${grayColor};
-    transition: all 0.3s ease;
+    transition: all 0.5s ease;
   }
   &:hover,
   &:active {
@@ -112,15 +113,4 @@ export const AttachImageInput = styled.input`
   display: none;
 `;
 
-export const SubmitButton = styled.button`
-  background-color: ${primaryColor};
-  border: none;
-  border-radius: 20px;
-  color: white;
-  font-size: 16px;
-  line-height: 36px;
-  svg {
-    width: 36px;
-    height: 36px;
-  }
-`;
+export const SubmitButton = styled(SolidButton)``;

--- a/src/utils/use-esc-close.tsx
+++ b/src/utils/use-esc-close.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+const useEscClose = (onClose: () => void) => {
+  useEffect(() => {
+    const handleEscKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleEscKey);
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [onClose]);
+};
+
+export default useEscClose;


### PR DESCRIPTION
6a7ac12 [💎 : refactor] 유저 프로필 컴포넌트 분리 (#9)
- 프로필 수정 기능 확대를 위해 profile 관련 컴포넌트 분리 작업 진행

58e15ee [🥁 : feat] 프로필 수정 UI 변경 (#9) 및 이름 수정 기능 추가 (#5)
- 프로필 수정 컴포넌트를 팝업으로 분리 (edit-profile-form) 그로인한 스타일링 작업
- 유저 이름 변경 기능 추가. users 문서의 userName 필드 수정을 위해서는 updateDoc 메서드를, user 객체의 displayName 수정을 위해서는 updateProfile 메서드를 활용.
- 프로필 이미지 제거 기능 추가. 마찬가지로 user 객체의 photoURL 함께 변경되도록 작업
- 추가 작업 필요) 변경된 유저 정보에 따라 자동 리렌더링 필요

a9f0081 [🥁 : feat] 타임라인에 글이 없는 경우 텍스트 노출 (#17)

bdc54d3 [🥁 : feat] esc키로 닫기 함수 유틸로 분리 후 공통 적용 (#18)