### PR TITLE
검색 결과 개선 (#4 #23)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ const router = createBrowserRouter([
         element: <Profile />,
       },
       {
-        path: `/search/:searchKeyword`,
+        path: `/search`,
         element: <SearchResult />,
       },
     ],

--- a/src/assets/images/i-change.svg
+++ b/src/assets/images/i-change.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+</svg>

--- a/src/components/profile/edit-profile-form.tsx
+++ b/src/components/profile/edit-profile-form.tsx
@@ -13,6 +13,7 @@ import CompressImage from '@util/compress-image.tsx';
 import useEscClose from '@util/use-esc-close.tsx';
 import * as S from '@style/profile-form.ts';
 import { ReactComponent as IconUser } from '@img/i-user.svg';
+import { ReactComponent as IconChange } from '@img/i-change.svg';
 import { ReactComponent as LoadingSpinner } from '@img/loading-spinner-mini.svg';
 
 interface IEditProfileForm extends Pick<IUser, 'userAvatar' | 'userName'> {
@@ -97,7 +98,7 @@ export default function EditProfileForm({
   return (
     <S.Form onSubmit={onSubmit}>
       {avatarPreview ? (
-        <>
+        <S.AttachAvatar>
           <S.AttachAvatarPreview
             src={avatarPreview}
             alt="프로필이미지 미리보기"
@@ -105,11 +106,14 @@ export default function EditProfileForm({
             height="120"
           />
           <S.AttachAvatarDelete type="button" onClick={onAvatarDelete} />
-        </>
+          <S.AttachAvatarChange htmlFor="avatar_edit">
+            <IconChange />
+          </S.AttachAvatarChange>
+        </S.AttachAvatar>
       ) : (
-        <S.AttachAvatarButton htmlFor="avatar_edit">
+        <S.AttachAvatarLabel htmlFor="avatar_edit">
           <IconUser />
-        </S.AttachAvatarButton>
+        </S.AttachAvatarLabel>
       )}
       <S.AttachAvatarInput
         onChange={onAvatarChange}

--- a/src/components/search-result/search-timeline.tsx
+++ b/src/components/search-result/search-timeline.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
   collection,
   getDocs,
@@ -7,16 +8,21 @@ import {
   query,
   where,
 } from 'firebase/firestore';
-import { useRecoilValue } from 'recoil';
 import { db } from '@/firebase.ts';
+import { useRecoilValue } from 'recoil';
 import { searchKeywordAtom } from '@/atoms.tsx';
 import Tweet from '@compo/home/tweet.tsx';
 import ITweet from '@type/ITweet.ts';
 import * as S from '@style/timeline.ts';
 
 export default function SearchTimeline() {
+  const location = useLocation();
   const [tweets, setTweets] = useState<ITweet[]>([]);
-  const searchKeyword = useRecoilValue(searchKeywordAtom);
+  const searchKeywordFromLocation = decodeURIComponent(
+    location.search.slice(7),
+  );
+  const searchKeywordAtomValue = useRecoilValue(searchKeywordAtom);
+  const searchKeyword = searchKeywordFromLocation || searchKeywordAtomValue;
   const fetchTweets = async () => {
     const tweetsQuery = query(
       collection(db, 'tweets'),
@@ -50,6 +56,8 @@ export default function SearchTimeline() {
       ))}
     </S.TimelineWrapper>
   ) : (
-    <S.Text>검색 결과가 없습니다.</S.Text>
+    <S.Text>
+      [<span>{searchKeyword}</span>] 에 대한 검색 결과가 없습니다.
+    </S.Text>
   );
 }

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { searchKeywordAtom } from '@/atoms.tsx';
 import WindowTop from '@compo/window-top.tsx';
@@ -10,22 +10,16 @@ import { ReactComponent as IconSearch } from '@img/i-search.svg';
 export default function Search() {
   const navigate = useNavigate();
   const [searchValue, setSearchValue] = useState('');
-  const [searchKeyword, setSearchKeyword] = useRecoilState(searchKeywordAtom);
+  const setSearchKeyword = useSetRecoilState(searchKeywordAtom);
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
   };
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (searchValue === '') return;
     setSearchKeyword(searchValue);
     setSearchValue('');
-    navigate(`/search/searchKeyword=${searchKeyword}`);
+    navigate(`/search?query=${searchValue}`);
   };
-  useEffect(() => {
-    if (searchKeyword) {
-      navigate(`/search/searchKeyword=${searchKeyword}`);
-    }
-  }, [searchKeyword, navigate]);
   return (
     <W.Window>
       <WindowTop />

--- a/src/styles/profile-form.ts
+++ b/src/styles/profile-form.ts
@@ -12,23 +12,33 @@ export const Form = styled.form`
   align-items: center;
 `;
 
-export const AttachAvatarPreview = styled.img`
+export const AttachAvatar = styled.div`
+  position: relative;
   width: 120px;
   height: 120px;
   margin-bottom: 20px;
+`;
+
+export const AttachAvatarPreview = styled.img`
+  width: 120px;
+  height: 120px;
   object-fit: cover;
   border-radius: 50%;
 `;
 
-export const AttachAvatarDelete = styled.button`
+export const AttachAvatarButton = styled.button`
   position: absolute;
   top: 0;
-  right: 70px;
+
   width: 25px;
   height: 25px;
   background-color: ${primaryColor};
   border: 2px solid ${whiteColor};
   border-radius: 50%;
+`;
+
+export const AttachAvatarDelete = styled(AttachAvatarButton)`
+  left: 10px;
   &::before,
   &::after {
     content: '';
@@ -47,7 +57,23 @@ export const AttachAvatarDelete = styled.button`
   }
 `;
 
-export const AttachAvatarButton: React.ComponentType<
+export const AttachAvatarChange: React.ComponentType<
+  React.HTMLProps<HTMLLabelElement>
+> = styled(AttachAvatarButton).attrs(() => ({ as: 'label' }))`
+  right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  svg {
+    width: 15px;
+    height: 15px;
+    stroke: ${whiteColor};
+    stroke-width: 3px;
+  }
+`;
+
+export const AttachAvatarLabel: React.ComponentType<
   React.HTMLProps<HTMLLabelElement>
 > = styled(Avatar).attrs(() => ({
   as: 'label',

--- a/src/styles/timeline.ts
+++ b/src/styles/timeline.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { primaryColor } from '@style/global.ts';
 
 export const TimelineWrapper = styled.ul`
   display: block;
@@ -9,4 +10,8 @@ export const TimelineWrapper = styled.ul`
 export const Text = styled.p`
   margin: 20px 0;
   text-align: center;
+  span {
+    color: ${primaryColor};
+    font-weight: 600;
+  }
 `;


### PR DESCRIPTION
7d759b7 [🎀 : style] 프로필 이미지 수정 버튼 추가
- before) 기존에 등록된 이미지를 삭제한 뒤에 새로 등록해야만 했음
- after) 등록한 이미지가 있는 경우에도 바로 이미지 변경할 수 있도록 함

8eedd32 [🛠 : fix] 검색 결과 경로 한 번에 이동하도록 수정 (#4)
- before) searchKeyword가 빈채로 경로 이동한 뒤 다시 적절한 경로로 재이동
- after) searchKeyword로 한 번에 이동
-  setSearchKeyword(searchValue) 동작이 한발짝 늦는것이 문제로 원인 파악. searchValue로 navigate하면서 해결. 불필요한 비동기 동작 및 useEffect 코드 제거
- 검색결과 쿼리 깔끔하게 다듬기

e441194 [🥁 : feat] 검색 결과 url로 접근 및 새로고침 활성화 (#23)
- before) 검색창에 입력한 키워드를 atom에 저장한 뒤 가져와 사용하는 형태이기 때문에 새로고침하거나 url로 접근하는 경우는 결과를 불러올 수 없었음
- after) useLocation을 활용해 url에 입력된 값을 저장해 atom과 비교하며 사용
- decodeURLComponent : 자바스크립트 URL 디코딩 메서드. 암호화된 한글을 해독
- useParams는 router로 바로 연결된 컴포넌트가 아니면 활용할 수 없음을 유의. 대신에 useLocation을 채택함