### PR TITLE
내 프로필 페이지에서 모든 유저 프로필 페이지로 기능 확장 (#2) & 회원 탈퇴 기능 추가 (#21)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter([
         element: <Home />,
       },
       {
-        path: '/:user',
+        path: '/user',
         element: <Profile />,
       },
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter([
         element: <Home />,
       },
       {
-        path: '/profile',
+        path: '/:user',
         element: <Profile />,
       },
       {

--- a/src/components/home/tweet.tsx
+++ b/src/components/home/tweet.tsx
@@ -57,7 +57,7 @@ export default function Tweet({
   }, [userId]);
   return (
     <S.Wrapper>
-      <S.Avatar>
+      <S.Avatar to={`/${userId}`}>
         {userAvatar ? (
           <S.AvatarImage
             src={userAvatar}
@@ -70,7 +70,7 @@ export default function Tweet({
         )}
       </S.Avatar>
       <S.Row>
-        <S.Username>{userName}</S.Username>
+        <S.Username to={`/${userId}`}>{userName}</S.Username>
         <S.Date>{FormatDate(createdAt)}</S.Date>
       </S.Row>
       <S.Payload>{tweet}</S.Payload>

--- a/src/components/home/tweet.tsx
+++ b/src/components/home/tweet.tsx
@@ -57,7 +57,7 @@ export default function Tweet({
   }, [userId]);
   return (
     <S.Wrapper>
-      <S.Avatar to={`/${userId}`}>
+      <S.Avatar to={`/user?query=${userId}`}>
         {userAvatar ? (
           <S.AvatarImage
             src={userAvatar}
@@ -70,7 +70,7 @@ export default function Tweet({
         )}
       </S.Avatar>
       <S.Row>
-        <S.Username to={`/${userId}`}>{userName}</S.Username>
+        <S.Username to={`/user?query=${userId}`}>{userName}</S.Username>
         <S.Date>{FormatDate(createdAt)}</S.Date>
       </S.Row>
       <S.Payload>{tweet}</S.Payload>

--- a/src/components/left-side-menu/navigation.tsx
+++ b/src/components/left-side-menu/navigation.tsx
@@ -1,4 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import currentUserAtom from '@atom/current-user.tsx';
 import * as S from '@style/navigation.ts';
 import ImageComputer from '@img/logo-small.png';
 import { ReactComponent as IconUser } from '@img/i-user.svg';
@@ -6,6 +8,7 @@ import { ReactComponent as IconHome } from '@img/i-home.svg';
 
 export default function Navigation() {
   const location = useLocation();
+  const currentUser = useRecoilValue(currentUserAtom);
   return (
     <>
       <S.Logo>
@@ -20,8 +23,10 @@ export default function Navigation() {
             <IconHome /> 홈
           </Link>
         </S.MenuItem>
-        <S.MenuItem $isActive={location.pathname === '/profile'}>
-          <Link to="/profile">
+        <S.MenuItem
+          $isActive={location.search === `?query=${currentUser.userId}`}
+        >
+          <Link to={`/user?query=${currentUser.userId}`}>
             <IconUser /> 프로필
           </Link>
         </S.MenuItem>

--- a/src/components/profile/user-profile.tsx
+++ b/src/components/profile/user-profile.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import currentUserAtom from '@atom/current-user.tsx';
+import IUser from '@type/IUser.ts';
 import EditProfileForm from '@compo/profile/edit-profile-form.tsx';
 import * as S from '@style/profile.ts';
 import * as P from '@style/popup.ts';
 import { ReactComponent as IconUser } from '@img/i-user.svg';
 
-export default function UserProfile() {
+interface IUserProfile {
+  user: IUser;
+}
+
+export default function UserProfile({ user }: IUserProfile) {
   const [editPopup, setEditPopup] = useState(false);
   const currentUser = useRecoilValue(currentUserAtom);
   const toggleEditPopup = () => {
@@ -15,10 +20,10 @@ export default function UserProfile() {
   return (
     <S.Profile>
       <S.Avatar>
-        {currentUser.userAvatar ? (
+        {user.userAvatar ? (
           <S.AvatarImage
-            src={currentUser.userAvatar}
-            alt={`${currentUser.userName}의 프로필 사진`}
+            src={user.userAvatar}
+            alt={`${user.userName}의 프로필 사진`}
             width="120"
             height="120"
           />
@@ -26,18 +31,22 @@ export default function UserProfile() {
           <IconUser />
         )}
       </S.Avatar>
-      <S.Name>{currentUser.userName}</S.Name>
-      <S.EditButton onClick={toggleEditPopup} type="button">
-        프로필 수정
-      </S.EditButton>
-      {editPopup ? (
-        <P.PopupWrapper>
-          <P.Popup>
-            <P.CloseButton onClick={toggleEditPopup} type="button" />
-            <EditProfileForm onClose={toggleEditPopup} />
-          </P.Popup>
-        </P.PopupWrapper>
-      ) : null}
+      <S.Name>{user.userName}</S.Name>
+      {user.userId === currentUser.userId && (
+        <>
+          <S.EditButton onClick={toggleEditPopup} type="button">
+            프로필 수정
+          </S.EditButton>
+          {editPopup && (
+            <P.PopupWrapper>
+              <P.Popup>
+                <P.CloseButton onClick={toggleEditPopup} type="button" />
+                <EditProfileForm onClose={toggleEditPopup} />
+              </P.Popup>
+            </P.PopupWrapper>
+          )}
+        </>
+      )}
     </S.Profile>
   );
 }

--- a/src/components/profile/user-timeline.tsx
+++ b/src/components/profile/user-timeline.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { Unsubscribe } from 'firebase/auth';
 import {
   collection,
@@ -9,21 +8,24 @@ import {
   query,
   where,
 } from 'firebase/firestore';
-import currentUserAtom from '@atom/current-user.tsx';
 import { db } from '@/firebase.ts';
+import IUser from '@type/IUser.ts';
 import ITweet from '@type/ITweet.ts';
 import Tweet from '@compo/home/tweet.tsx';
 import * as S from '@style/timeline.ts';
 
-export default function UserTimeline() {
+interface IUserTimeline {
+  user: IUser;
+}
+
+export default function UserTimeline({ user }: IUserTimeline) {
   const [tweets, setTweets] = useState<ITweet[]>([]);
-  const currentUser = useRecoilValue(currentUserAtom);
   useEffect(() => {
     let unsubscribe: Unsubscribe | null = null;
     const fetchTweets = async () => {
       const tweetsQuery = query(
         collection(db, 'tweets'),
-        where('userId', '==', currentUser.userId),
+        where('userId', '==', user.userId),
         orderBy('createdAt', 'desc'),
         limit(25),
       );
@@ -48,7 +50,7 @@ export default function UserTimeline() {
         unsubscribe();
       }
     };
-  }, [currentUser.userId]);
+  }, [user]);
   return tweets.length !== 0 ? (
     <S.TimelineWrapper>
       {tweets.map((tweet) => (

--- a/src/components/protected-route.tsx
+++ b/src/components/protected-route.tsx
@@ -15,8 +15,8 @@ export default function ProtectedRoute({
   if (!user || localStorageUser.userId === '') {
     auth.signOut().then(() => {
       setLocalStorageUser({ userId: '', userName: '', userAvatar: '' });
-      <Navigate to="/auth" />;
     });
+    return <Navigate to="/auth" />;
   }
   return children;
 }

--- a/src/components/protected-route.tsx
+++ b/src/components/protected-route.tsx
@@ -13,9 +13,10 @@ export default function ProtectedRoute({
   const [localStorageUser, setLocalStorageUser] =
     useRecoilState(currentUserAtom);
   if (!user || localStorageUser.userId === '') {
-    auth.signOut();
-    setLocalStorageUser({ userId: '', userName: '', userAvatar: '' });
-    return <Navigate to="/auth" />;
+    auth.signOut().then(() => {
+      setLocalStorageUser({ userId: '', userName: '', userAvatar: '' });
+      <Navigate to="/auth" />;
+    });
   }
   return children;
 }

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,17 +1,20 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { db } from '@/firebase.ts';
 import WindowTop from '@compo/window-top.tsx';
 import UserProfile from '@compo/profile/user-profile.tsx';
 import UserTimeline from '@compo/profile/user-timeline.tsx';
-import * as W from '@style/window.ts';
-import { collection, getDocs, query, where } from 'firebase/firestore';
-import { db } from '@/firebase.ts';
+import currentUserAtom from '@atom/current-user.tsx';
 import IUser from '@type/IUser.ts';
+import * as W from '@style/window.ts';
 
 export default function Profile() {
   const location = useLocation();
   const userFromLocation = location.search.slice(7);
   const [user, setUser] = useState<IUser | undefined>();
+  const currentUser = useRecoilValue(currentUserAtom);
   useEffect(() => {
     const fetchUser = async () => {
       const usersQuery = query(
@@ -27,7 +30,7 @@ export default function Profile() {
       }
     };
     fetchUser();
-  }, [userFromLocation]);
+  }, [userFromLocation, currentUser]);
   return (
     <W.Window>
       <WindowTop />

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,14 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import WindowTop from '@compo/window-top.tsx';
 import UserProfile from '@compo/profile/user-profile.tsx';
 import UserTimeline from '@compo/profile/user-timeline.tsx';
 import * as W from '@style/window.ts';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { db } from '@/firebase.ts';
+import IUser from '@type/IUser.ts';
 
 export default function Profile() {
+  const location = useLocation();
+  const userFromLocation = location.search.slice(7);
+  const [user, setUser] = useState<IUser | undefined>();
+  useEffect(() => {
+    const fetchUser = async () => {
+      const usersQuery = query(
+        collection(db, 'users'),
+        where('userId', '==', userFromLocation),
+      );
+      const snapshot = await getDocs(usersQuery);
+      if (!snapshot.empty) {
+        const userData = snapshot.docs[0].data() as IUser;
+        setUser(userData);
+      } else {
+        console.error("can't find user data");
+      }
+    };
+    fetchUser();
+  }, [userFromLocation]);
   return (
     <W.Window>
       <WindowTop />
-      <UserProfile />
-      <UserTimeline />
+      {user && (
+        <>
+          <UserProfile user={user} />
+          <UserTimeline user={user} />
+        </>
+      )}
     </W.Window>
   );
 }

--- a/src/styles/popup.ts
+++ b/src/styles/popup.ts
@@ -97,6 +97,9 @@ export const Text = styled.p`
   font-size: 18px;
   line-height: 30px;
   text-align: center;
+  span {
+    color: ${primaryColor};
+  }
 `;
 
 export const ButtonWrapper = styled.div`

--- a/src/styles/profile.ts
+++ b/src/styles/profile.ts
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 import { grayColor } from '@style/global.ts';
-import { LineButton } from '@style/button.ts';
+import { LineButton, SolidButton } from '@style/button.ts';
 
 export const Profile = styled.article`
   position: relative;
@@ -60,7 +60,16 @@ export const Name = styled.h2`
   font-size: 30px;
 `;
 
-export const EditButton = styled(LineButton)`
+export const Buttons = styled.div`
+  display: inline-block;
+`;
+
+export const EditButton = styled(SolidButton)`
   width: auto;
-  margin: 0;
+  margin: 0 5px;
+`;
+
+export const WithdrawButton = styled(LineButton)`
+  width: auto;
+  margin: 0 5px;
 `;

--- a/src/styles/tweet.ts
+++ b/src/styles/tweet.ts
@@ -1,5 +1,6 @@
 import { styled } from 'styled-components';
 import { grayColor, primaryColor } from '@style/global.ts';
+import { Link } from 'react-router-dom';
 
 export const Wrapper = styled.li`
   position: relative;
@@ -13,7 +14,7 @@ export const Wrapper = styled.li`
 
 export const Row = styled.div``;
 
-export const Avatar = styled.div`
+export const Avatar = styled(Link)`
   position: absolute;
   top: 20px;
   left: 10px;
@@ -50,9 +51,10 @@ export const AvatarImage = styled.img`
   z-index: 10;
 `;
 
-export const Username = styled.span`
+export const Username = styled(Link)`
   font-weight: 600;
   font-size: 15px;
+  text-decoration: none;
 `;
 
 export const Date = styled.span`


### PR DESCRIPTION
### 에러
0ee2623 [🛠 : fix] auth.signOut() 완료 이후에 상태 업데이트 및 리디렉션 수행
![image](https://github.com/sryung1225/Zwitter/assets/26590099/2400b274-dd74-4f75-9c63-dda90bed92a8)
- 코드 리팩토링 이전에 서비스에 가입한 유저에게 버그가 일어날 것을 대비해 로그아웃(auth.signOut())과 상태를 비워주는 로직을 추가하는 작업을 5296803 에서 진행했는데, 로그아웃이 완료되기 이전에 MiniProfile에서 setCurrenUser가 호출되어(상태를 업데이트하는 부분) 이 부분이 문제됨.
- 비동기 함수인 auth.signOut()가 우선 진행되고나서 상태를 변경 및 리디렉션을 하도록 하면 문제가 해결됨. MiniProfile에서는 비동기로 동작하고 있기 때문에 ProtectedRoute에서 누락된 비동기 동작(then)을 추가하여 해결

### 기능
c438e20 [🥁 : feat] 회원 탈퇴 (#21)
- 프로필 수정 버튼과 동일하게 로그인 유저에게만 회원 탈퇴 버튼 노출
- 회원 탈퇴 시 auth, firestore의 users컬렉션 문서, storage의 avatar 이미지 데이터 일괄 삭제 진행 후 /auth로 이동

870fead [🥁 : feat] 프로필 경로 수정 및 진입 링크 추가 (#2)
9fec024 [🥁 : feat] 프로필 경로 수정 및 네비게이션 스타일 활성화 조건 수정 (#2)
471ce4a [🥁 : feat] 내 프로필 -> 모든 유저 프로필로 컴포넌트 수정 (#2)
- Profile을 currentUser를 이용해 현재 로그인된 유저의 정보를 보여주는 용도의 페이지에서 확장. Timeline에서 props로 내려주는 유저 데이터를 기반으로 모든 유저의 프로필 페이지로 기능을 수정함
- '프로필 수정' 버튼은 currentUser와 props user를 비교하여 일치하는 경우에만 렌더링